### PR TITLE
return registered user lists in WebAPI

### DIFF
--- a/lib/Act/Handler/WebAPI.pm
+++ b/lib/Act/Handler/WebAPI.pm
@@ -17,6 +17,7 @@ my %Methods = (
                                    country town web_page pm_group pause_id monk_id monk_name im email
                                    language timezone
                                    company address vat
+                                   registered
                                 )),
                          },
                          default => [ qw(public_name email) ],
@@ -69,12 +70,14 @@ sub handler
 sub _get_attendees
 {
     my ($m, $fields) = @_;
+    my %fields = map { $_ => 1 } @$fields;
+    my @fields = grep { !/registered/ } @$fields;
 
     my $users = Act::User->get_items( conf_id => $Request{conference} );
     my @data;
     for my $user (@$users) {
-        push @data, _get_fields($m, $fields, $user)
-            if $user->committed;
+        push @data, _get_fields($m, \@fields, $user)
+            if($user->committed || ($user->has_registered && $fields{registered}});
     }
     return \@data;
 }


### PR DESCRIPTION
Free conferences don't have committed attendees. Once registered, users are assumed to be attendees. As such populating the user list for conference surveys only gets the admins and speakers :(

This patch hopefully allows for a full list of the registered users, if the field 'registered' is requested via the API.

If possible could this be patched, tested and put live so I can run the survey for the London Perl Workshop on 12th November. Thanks in advance.
