### PR TITLE
Link the PAUSE id to MetaCPAN

### DIFF
--- a/templates/core/user/change
+++ b/templates/core/user/change
@@ -270,9 +270,9 @@
 <tr>
    <td align="right">
       [%- IF pause_id %]
-         <a href="http://search.cpan.org/author/[% pause_id %]/" >
+         <a href="https://metacpan.org/author/[% pause_id %]/" >
       [% END %]
-      Pause id
+      <a href="https://pause.perl.org/">PAUSE</a> id
       [%- IF pause_id %]
          </a>
       [% END %]

--- a/templates/core/user/show
+++ b/templates/core/user/show
@@ -77,11 +77,11 @@
 [%- IF user.pause_id %]
    </tr><tr>
       <td align="right">
-         Pause id
+         <a href="https://pause.perl.org/">PAUSE</a> id
       </td>
       <td>&nbsp;</td>
       <td align="left">
-         <a href="http://search.cpan.org/author/[% user.pause_id %]/" >[% user.pause_id %]</a>
+         <a href="https://metacpan.org/author/[% user.pause_id %]/" >[% user.pause_id %]</a>
       </td>
 [% END %]
 [%- IF user.monk_id %]


### PR DESCRIPTION
[MetaCPAN](https://metacpan.org/) has a more complete profile page where CPAN users can link to
all their other accounts (Github, StackOverflow...), so this is more
useful as a CPAN author page than search.cpan.org.

Also link the "PAUSE id" label to the PAUSE site as this may not be
obvious to Perl beginners that come to the conferences.
