### PR TITLE
Auto register users that sign up at a conference site

### DIFF
--- a/lib/Act/User.pm
+++ b/lib/Act/User.pm
@@ -127,7 +127,7 @@ sub register_participation {
         LIMIT 1
   });
                                 
-  $sth->execute( $Request{user}->user_id );
+  $sth->execute( $self->user_id );
   my ($tshirt_size) = $sth->fetchrow_array;
   $sth->finish;
                                 

--- a/lib/Act/User.pm
+++ b/lib/Act/User.pm
@@ -115,7 +115,34 @@ sub talks {
     my ($self, %args) = @_;
     return Act::Talk->get_talks( %args, user_id => $self->user_id );
 }
-
+sub register_participation {
+  my ( $self ) = @_;
+  
+  my $sth = $Request{dbh}->prepare_cached(q{
+        SELECT  tshirt_size
+        FROM    participations
+        WHERE   user_id = ?
+        AND tshirt_size is not null
+        ORDER BY datetime DESC
+        LIMIT 1
+  });
+                                
+  $sth->execute( $Request{user}->user_id );
+  my ($tshirt_size) = $sth->fetchrow_array;
+  $sth->finish;
+                                
+  # create a new participation to this conference
+  $sth = $Request{dbh}->prepare_cached(q{
+        INSERT INTO participations
+          (user_id, conf_id, datetime, ip, tshirt_size)
+        VALUES  (?,?, NOW(), ?, ?)
+  });
+  
+  $sth->execute( $self->user_id, $Request{conference},
+    $Request{r}->connection->remote_ip, $tshirt_size );
+  $sth->finish();
+  $Request{dbh}->commit;
+}
 sub participation {
     my ( $self ) = @_;
     my $sth = sql('SELECT * FROM participations p WHERE p.user_id=? AND p.conf_id=?',


### PR DESCRIPTION
Hi,

This is a pull-request from the Norwegian community. We are planning to use Act for the OSDC 2015 conference and certain people have been quite annoyed that when users will register at the osdc.no site they are actually not registered for the conference. The purpose of this small change is to autoregister newly registered users for the conference instance they are currently in.
I think this makes sense because new users will in most cases create an account because they want to go to this particular conference. So it makes sense to have them automatically tagged as participants.  In the rare cases that this is not the case the user as before has the opportunity to unregister from the conference.

I notice that the vagrant image from the Act-Voyager branch is not working so this code suggestion is not tested at ALL. Please apply with caution :)

Best regards
Joakim