### PR TITLE
Added updatemytalks_as private handler and sub ajax_stateful_handler

### DIFF
--- a/lib/Act/Dispatcher.pm
+++ b/lib/Act/Dispatcher.pm
@@ -69,6 +69,7 @@ my %private_handlers = (
     tracks          => 'Act::Handler::Track::List',
     updatemytalks   => 'Act::Handler::User::UpdateMyTalks',
     updatemytalks_a => 'Act::Handler::User::UpdateMyTalks::ajax_handler',
+    updatemytalks_as => 'Act::Handler::User::UpdateMyTalks::ajax_stateful_handler',
     unregister      => 'Act::Handler::User::Unregister',
     wikiedit        => 'Act::Handler::WikiEdit',
 );

--- a/lib/Act/Handler/User/UpdateMyTalks.pm
+++ b/lib/Act/Handler/User/UpdateMyTalks.pm
@@ -47,6 +47,27 @@ sub ajax_handler
     $Request{status} = HTTP_NO_CONTENT;
 }
 
+# same as ajax_handler but not toggle: accept 'state' direct parameter
+sub ajax_stateful_handler
+{
+    if( $Request{user}->has_registered && $Request{args}{talk_id} ) {
+
+        my $talk = Act::Talk->new(
+            talk_id => $Request{args}{talk_id},
+            conf_id => $Request{conference} );
+
+        my $my_talks = $Request{user}->my_talks;
+
+        $Request{user}->update_my_talks(
+            # pre-remove selected talk, if it exists:
+            grep({ $_->talk_id != $talk->talk_id } @$my_talks),
+            # and add it back, or don't add, depending from 'state' argument:
+            ($Request{args}{state} ? $talk : ()) );
+    }
+
+    $Request{status} = HTTP_NO_CONTENT;
+}
+
 1;
 
 =head1 NAME


### PR DESCRIPTION
Added 'updatemytalks_as' for ajax_stateful_handler to specifically set or clean user's
favorite task, not to toggle.

On some pages of YAPC::EU::2015 there is few 'favorite' buttons for same task,
and when they both off and visitor presses them one-by-one, they both become
toggled to 'on' state, but two in a row request to old updatemytalks_a handler
toggles task in favorites from off to on and back to off.

So we need separate handler:
- updatemytalks_a -> toggles by 'task_id' in request.
- updatemytalks_as -> sets 'task_id' favorite state depending from additional 'state' parameter

For latter one we already provide preparations in javascript already, there:
https://github.com/Act-Conferences/ye2015/blob/master/wwwdocs/js/main.js#L22-L26
