### PR TITLE
Fix JS error preventing people from starring talks at LPW2015

### DIFF
--- a/templates/js/mytalks.js
+++ b/templates/js/mytalks.js
@@ -31,7 +31,7 @@ if (window.act) {
     $(function() {
         $(".mytalks_submit").remove();
         $(":checkbox").each(function() {
-            toggle_image(this, $(this).val(), $(this).prop("checked"));
+            toggle_image(this, $(this).val(), $(this).attr("checked"));
         });
     });
 }


### PR DESCRIPTION
Reverts commit 0f91e321a04b3262657ca63dcfdf74e61bc82a4f

Revert "apparently, one must check whether a checkbox is checked or not using .prop() and no longer with .attr(), since jQuery 1.6+"

The commit was right, _but_ act uses jQuery 1.3.2 which doesn't support
prop() and therefore attr() is correct to be used.