### PR TITLE
Make user search by PM group case insensitive

### DIFF
--- a/lib/Act/User.pm
+++ b/lib/Act/User.pm
@@ -38,7 +38,7 @@ our %sql_mapping = (
     map( { ($_, "(lower(u.$_)=lower(?))") }
       qw( first_name last_name) ),
     # user can have multiple entries in pm_group
-    pm_group => "position(? in u.pm_group) > 0",
+    pm_group => "position(lower(?) in lower(u.pm_group)) > 0",
     # standard stuff
     map( { ($_, "(u.$_=?)") }
       qw( user_id session_id login email country ) )

--- a/t/10user.t
+++ b/t/10user.t
@@ -1,4 +1,4 @@
-use Test::More tests => 51;
+use Test::More tests => 52;
 use strict;
 use Act::User;
 use t::Util;   # load the test database
@@ -56,6 +56,10 @@ is_deeply( Act::User->get_users( name => 'baz' ), [ $user ], "Found a pseudonymo
 # use a * in the search field
 $user = Act::User->new( login => 'test2' );
 is_deeply( Act::User->get_users( name => 'b*' ), [ $user ], "Found a user with a glob" );
+
+# fetch a user by PM group case-insensitively
+$user = Act::User->new( login => 'test2' );
+is_deeply( Act::User->get_users( pm_group => 'Paris.PM' ), [ $user ], "Found a user by case insensitive pm_group" );
 
 # update a user
 $user = Act::User->new( login => 'test' );


### PR DESCRIPTION
The stats page and search dropdown case-normalise PM groups, but the
search was being case sensitive.

