### PR TITLE
Fix one-time test failure in t/04template.t

### DIFF
--- a/t/04template.t
+++ b/t/04template.t
@@ -288,7 +288,7 @@ my @html_templates = (
     },
 );
 use Test::More;
-plan tests => 3 * (@templates + @html_templates) + 13;
+plan tests => 3 * (@templates + @html_templates) + 14;
 
 require_ok('Act::Template');
 my $template = Act::Template->new;
@@ -310,6 +310,13 @@ ok(eq_hash($template->variables(), \%h), "variables get hash");
 $template->clear;
 is($template->variables($_), undef, "clear $_") for keys %h;
 ok(eq_hash($template->variables(), {}), "clear");
+
+# compile 'common' template PREPROCESSed by Act::Template
+my $junk = '';
+$Request{language} = 'fr';
+ok($template->process(\$junk,\$junk),
+   "compile PREPROCESSed templates");
+$template->clear;
 
 for my $t (@templates) {
     _ttest($template, $t);


### PR DESCRIPTION
When I run the test suite after a fresh installation of Act, t/04template fails at the third test when the first template is to be processed (test nr. 14):
`is_deeply($template->{PARSER}->sections, $t->{sections}, "$t->{name} sections");`
If I run it again, the test passes, everytime from there.  Unless I delete the directory containing the compiled templates: After that, I again have one test failure, and passes thereafter.

This may be related to the version of Template Toolkit (I'm using 2.28), but here's the root cause: When the first template is processed for the first time, parsing of the the to-be PRE_PROCESSed "common" template is invoked by TT _after_ parsing the test template.  So, the Template parser (Template::Multilingual::Parser) holds the "common" template in its sections instead of the test template.

All following test runs use the compiled "common" template, so the test template remains in the parser object, and everything is fine.
