### PR TITLE
Bugfix: Allow hide_details and allow_record to be cleared

### DIFF
--- a/lib/Act/Handler/Talk/Edit.pm
+++ b/lib/Act/Handler/Talk/Edit.pm
@@ -105,7 +105,9 @@ sub handler {
 
         # validate form fields
         my $ok = $form->validate($Request{args});
-        $fields = { accepted => 0, confirmed => 0, track_id => undef, %{$form->{fields}} };
+        $fields = { accepted => 0, confirmed => 0,
+                    hide_details => 0, allow_record => 0, # pre-set checkboxes
+                    track_id => undef, %{$form->{fields}} };
 
         # organizer specifies user id
         my $user_id = $Request{user}->is_talks_admin


### PR DESCRIPTION
Act currently doesn't allow to un-hide the details of a talk, or to revoke the admission to record a talk.
The root cause is in the checkboxes: If a checkbox isn't checked, then it isn't present (not even with an undefined value) in the HTTP request.  Therefore, the intention of an user to **uncheck** a box doesn't make its way to the SQL UPDATE statement.

This patch pre-sets the two checkboxes "hide_details" and "allow_record" with 0, allowing the form to override them if the corresponding box is checked.

Disclaimer: I tested this with an installation based on https://github.com/TBSliver/Act-Vagrant which should be pretty similar to what act.yapc.eu is running but might have newer versions of CPAN modules.
