### PR TITLE
Make sure that wiki texts passed to diff end in a linefeed

### DIFF
--- a/lib/Act/Handler/Wiki.pm
+++ b/lib/Act/Handler/Wiki.pm
@@ -133,8 +133,7 @@ sub wiki_diff
 
         $v{user} = Act::User->new(user_id => $v{metadata}{user_id}[0]);
         $v{last_modified} = DateTime::Format::Pg->parse_datetime($v{last_modified});
-        $v{content} .= "\n" if index($v{content}, "\n") == -1;
-
+        $v{content} =~ s/\n?$/\n/s;
         $versions{$r} = \%v;
     }
 


### PR DESCRIPTION
The current method to make sure that a wiki diff doesn't complain about "no linefeed at end of file" doesn't work if there is a linefeed _within_ the text.  The patch fixes that.